### PR TITLE
Fix issue #1: Enable real-time speech interruptions

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -102,6 +102,11 @@ export const ChatInterface: React.FC = () => {
   };
 
   const handleSendMessage = useCallback(async (text: string) => {
+    // Stop any ongoing speech when user sends a new message (interruption)
+    if (isAvatarSpeaking) {
+      avatarRef.current?.stopSpeech();
+    }
+
     const userMessage: ChatMessage = {
       id: uuidv4(),
       text,
@@ -157,7 +162,7 @@ export const ChatInterface: React.FC = () => {
       setIsTyping(false);
       setIsListening(false); // Hide listening state
     }
-  }, [isSpeechInitialized, speakWithLipSync, sendMessage]);
+  }, [isAvatarSpeaking, isSpeechInitialized, speakWithLipSync, sendMessage]);
 
   useEffect(() => {
     if (!isVoiceRecording && voiceFinalResult.trim()) {
@@ -169,9 +174,13 @@ export const ChatInterface: React.FC = () => {
   }, [handleSendMessage, isVoiceRecording, resetVoiceRecognition, voiceFinalResult]);
 
   const handleStartVoice = useCallback(() => {
+    // Stop any ongoing speech when user starts voice input (interruption)
+    if (isAvatarSpeaking) {
+      avatarRef.current?.stopSpeech();
+    }
     resetVoiceRecognition();
     void startRecording();
-  }, [resetVoiceRecognition, startRecording]);
+  }, [isAvatarSpeaking, resetVoiceRecognition, startRecording]);
 
   const handleStopVoice = useCallback(() => {
     void stopRecording();
@@ -252,7 +261,7 @@ export const ChatInterface: React.FC = () => {
 
       <MessageInput
         onSendMessage={handleSendMessage}
-        disabled={isTyping || isAvatarSpeaking}
+        disabled={isTyping}
         onStartVoice={isSpeechInitialized ? handleStartVoice : undefined}
         onStopVoice={isSpeechInitialized ? handleStopVoice : undefined}
         isVoiceRecording={isVoiceRecording}

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -167,8 +167,6 @@ export const useSpeechRecognition = (options: UseSpeechRecognitionOptions = {}) 
           () => disposeRecognizer(),
           () => disposeRecognizer()
         );
-      } else {
-        disposeRecognizer();
       }
     };
   }, [disposeRecognizer]);


### PR DESCRIPTION
## Summary
This PR implements real-time speech interruption capability, allowing users to interrupt the agent while it's speaking.

## Changes
- **ChatInterface.tsx**: 
  - Removed `isAvatarSpeaking` from input disabled condition to allow interruptions
  - Added automatic speech stop when user sends a new message
  - Added automatic speech stop when user starts voice input
  - Updated callback dependency arrays

- **useSpeechRecognition.ts**: 
  - Fixed bug in cleanup effect that caused "Cannot read properties of null (reading 'reject')" error
  - Removed unnecessary `disposeRecognizer()` call when recognizer is already null

## Testing
- ✅ Build compiles successfully
- ✅ Users can now type or use voice input while avatar is speaking
- ✅ Avatar speech stops immediately when interrupted
- ✅ No runtime errors when pressing voice button without speaking

Fixes #1